### PR TITLE
Fixed unsafe passing of Go pointers to C

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/LiamHaworth/macos-golang
 
-go 1.13
+go 1.17

--- a/systemConfiguration/dynamic_store.go
+++ b/systemConfiguration/dynamic_store.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"runtime/cgo"
 	"unsafe"
 
 	. "github.com/LiamHaworth/macos-golang/coreFoundation"
@@ -51,9 +52,9 @@ func DynamicStoreCreate(name string, callback DynamicStoreCallBack, context inte
 	store.context = context
 	store.callback = callback
 
-	maskedPointer := uintptr(unsafe.Pointer(store))
+	handle := cgo.NewHandle(store)
 
-	cfContext := C.CreateContext(unsafe.Pointer(&maskedPointer))
+	cfContext := C.CreateContext(unsafe.Pointer(handle))
 	cfName, _ := ToCFString(name)
 
 	store.ref = C.SCDynamicStoreCreate(0, (C.CFStringRef)(cfName), (*[0]byte)(C.goDynamicStoreCallback), cfContext)

--- a/systemConfiguration/dynamic_store_callback.go
+++ b/systemConfiguration/dynamic_store_callback.go
@@ -8,6 +8,7 @@ package systemConfiguration
 */
 import "C"
 import (
+	"runtime/cgo"
 	"unsafe"
 
 	. "github.com/LiamHaworth/macos-golang/coreFoundation"
@@ -17,9 +18,9 @@ import (
 func goDynamicStoreCallback(_ C.SCDynamicStoreRef, changedKeys C.CFArrayRef, context unsafe.Pointer) {
 	array, _ := FromCFArray((ArrayRef)(changedKeys))
 
-	maskedPointer := *(*uintptr)(context)
-	store := (*DynamicStore)(unsafe.Pointer(maskedPointer))
-	if store == nil || store.callback == nil {
+	handle := cgo.Handle(context)
+	store, ok := handle.Value().(*DynamicStore)
+	if !ok || store == nil || store.callback == nil {
 		return
 	}
 


### PR DESCRIPTION
Came across this issue where if switching user account, it causes violation panic. From what I can tell, it's due to an unsafe way of storing. Using `runtime/cgo` resolves the panic.

```
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x1 addr=0x527265726566655a pc=0x10495a228]

goroutine 51 gp=0xc000104380 m=5 mp=0xc000180008 [running, locked to thread]:
runtime.throw({0x104b40c68?, 0x1?})
	runtime/panic.go:1023 +0x5c fp=0xc000078cc0 sp=0xc000078c90 pc=0x1043c203c
runtime.sigpanic()
	runtime/signal_unix.go:895 +0x285 fp=0xc000078d20 sp=0xc000078cc0 pc=0x1043dac85
github.com/LiamHaworth/macos-golang/systemConfiguration.goDynamicStoreCallback(0x104ebff80?, 0x1043f5f01?, 0xc000120110)
	github.com/LiamHaworth/macos-golang@v0.3.0/systemConfiguration/dynamic_store_callback.go:22 +0x28 fp=0xc000078d60 sp=0xc000078d20 pc=0x10495a228
_cgoexp_f2eef1b04b2c_goDynamicStoreCallback(0x1043cde11?)
	_cgo_gotypes.go:456 +0x25 fp=0xc000078d88 sp=0xc000078d60 pc=0x10495a5c5
runtime.cgocallbackg1(0x10495a5a0, 0x30fdf1fa8, 0x0)
	runtime/cgocall.go:420 +0x295 fp=0xc000078e48 sp=0xc000078d88 pc=0x10438bc55
runtime.cgocallbackg(0x10495a5a0, 0x30fdf1fa8, 0x0)
	runtime/cgocall.go:339 +0x136 fp=0xc000078ec0 sp=0xc000078e48 pc=0x10438b916
runtime.cgocallbackg(0x10495a5a0, 0x30fdf1fa8, 0x0)
	<autogenerated>:1 +0x29 fp=0xc000078ee8 sp=0xc000078ec0 pc=0x1043fc0c9
runtime.cgocallback(0xc000078f48, 0x10438b535, 0x104b3e600)
	runtime/asm_amd64.s:1079 +0xcc fp=0xc000078f10 sp=0xc000078ee8 pc=0x1043f956c
runtime.systemstack_switch()
	runtime/asm_amd64.s:474 +0x8 fp=0xc000078f20 sp=0xc000078f10 pc=0x1043f7768
runtime.cgocall(0x104b3e600, 0xc000078f80)
	runtime/cgocall.go:175 +0x75 fp=0xc000078f58 sp=0xc000078f20 pc=0x10438b535
github.com/LiamHaworth/macos-golang/systemConfiguration._Cfunc_CFRunLoopRun()
	_cgo_gotypes.go:175 +0x3f fp=0xc000078f80 sp=0xc000078f58 pc=0x10495957f
github.com/LiamHaworth/macos-golang/systemConfiguration.(*DynamicStore).RunLoop(0xc00011e1b0)
	github.com/LiamHaworth/macos-golang@v0.3.0/systemConfiguration/dynamic_store.go:96 +0x89 fp=0xc000078fc8 sp=0xc000078f80 pc=0x10495a049
```